### PR TITLE
Adding the ability to set the paypal button style through the template

### DIFF
--- a/src/resources/js/paymentForm.js
+++ b/src/resources/js/paymentForm.js
@@ -4,11 +4,17 @@ function initCheckout() {
         setTimeout(initCheckout, 200);
     } else {
         var $wrapper = $('.paypal-rest-form');
+
+        var $styles = {};
+        if($wrapper.data('styles')){
+            $styles = $wrapper.data('styles');
+        }
+
         var $form = $wrapper.parents('form');
         var paymentUrl = $wrapper.data('prepare');
 
         paypal.Button.render({
-
+            style: $styles,
             env: $wrapper.data('env'),
             commit: true,
 

--- a/src/templates/express/paymentForm.html
+++ b/src/templates/express/paymentForm.html
@@ -1,4 +1,10 @@
-<div class="paypal-rest-form" data-env="{{ gateway.testMode ? 'sandbox' : 'production' }}"
-     data-prepare="{{ actionUrl('commerce/payments/pay') }}">
+<div class="paypal-rest-form"
+     data-env="{{ gateway.testMode ? 'sandbox' : 'production' }}"
+     data-prepare="{{ actionUrl('commerce/payments/pay') }}"
+     {% if style is defined %}
+        data-styles="{{ style|json_encode }}"
+     {% endif %}
+    >
     <div id="paypal-button"></div>
 </div>
+


### PR DESCRIPTION
Adding the ability to change the styles of the Paypal Express button 

Like so

`                            {{ gateway.getPaymentFormHtml({
                                threeDSecure:true,
                                style:{
                                    color: 'blue',
                                    size: 'large',
                                    tagline: 'false',
                                }
                            }) |raw }}
`